### PR TITLE
Update bmp581.py

### DIFF
--- a/micropython_bmp581/bmp581.py
+++ b/micropython_bmp581/bmp581.py
@@ -267,10 +267,12 @@ class BMP581:
         With the measured pressure p and the pressure at sea level p0 e.g. 1013.25hPa,
         the altitude in meters can be calculated with the international barometric formula
         """
+        # was ** 0.190284, should be ** 0.190295 or better ** (1.0 / 5.255))
         altitude = 44330.0 * (
-            1.0 - ((self.pressure / self.sea_level_pressure) ** 0.190284)
+            1.0 - ((self.pressure / self.sea_level_pressure) ** (1.0 / 5.255))
         )
-        return round(altitude, 1)
+        # was round(altitude, 1), rounding limits accuracy to 100cm, sensor +/- cm
+        return altitude
 
     @altitude.setter
     def altitude(self, value: float) -> None:


### PR DESCRIPTION
Fixes for two problems I rose as issues to the bmp581 altitude function.

1.   Exponent in altitude calculation was wrong: it was ** 0.190284, should be ** 0.190295 or better yet let the compiler do it with  ** (1.0 / 5.255))
2. function returns round(altitude, 1), but this rounding limits accuracy to 100cm, and the bmp581 sensor has accuracy of a few centimeters.

thanks for your great code!